### PR TITLE
Fix example and finalize README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,28 @@ A Python client for interacting with the Splunk® SOAR (Cloud and On-Premises) R
 
 ## Features
 
--   Simple and intuitive client for all major REST API actions.
--   Support for both token-based (`ph-auth-token`) and user/password authentication.
--   Logical grouping of API calls based on endpoint categories (Containers, Artifacts, Playbooks, etc.).
--   Built-in handling of HTTP requests, responses, and errors with a custom exception class.
--   Comprehensive coverage of endpoints.
+- Simple and intuitive client for all major REST API actions.
+- Support for both token-based (`ph-auth-token`) and user/password authentication.
+- Logical grouping of API calls based on endpoint categories (Containers, Artifacts, Playbooks, etc.).
+- Built-in handling of HTTP requests, responses, and errors with a custom exception class.
+- Comprehensive coverage of endpoints.
 
 ## Installation
 
 ```bash
 pip install splunk-soar-rest
+```
+
+## Basic Usage
+
+```python
+from splunk_soar_rest import SplunkSOARClient
+
+client = SplunkSOARClient(
+    base_url="https://your.soar.instance",
+    auth_token="your_ph_auth_token",
+    verify=False
+)
+version_info = client.get_version()
+print(version_info)
+```

--- a/examples/01_containers_and_artifacts.py
+++ b/examples/01_containers_and_artifacts.py
@@ -21,8 +21,7 @@ def main():
         container_data = {
             "name": "API Test - Phishing Email Reported",
             "label": "events",
-            "severity": "high",
-            "owner_id": "admin"
+            "severity": "high"
         }
         new_container = client.create_container(**container_data)
         container_id = new_container['id']


### PR DESCRIPTION
## Summary
- fix container example by removing invalid `owner_id`
- complete README with installation and usage section

## Testing
- `python -m compileall -q .`
- `python examples/01_containers_and_artifacts.py`

------
https://chatgpt.com/codex/tasks/task_e_6849f1b17fb883289ec8875bc70c0845